### PR TITLE
Small fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "test": "echo 'Add tests please :)'"
   },
   "dependencies": {
-    "@emotion/styled": "^11.11.0",
     "@icgc-argo/ego-token-utils": "^8.2.0",
     "@icgc-argo/uikit": "^3.0.1",
     "@types/url-join": "^4.0.1",
@@ -22,6 +21,9 @@
     "react-dom": "18.2.0",
     "react-query": "^3.39.3",
     "url-join": "^5.0.0"
+  },
+  "peerDependencies": {    
+    "@emotion/styled": "^11.11.0"
   },
   "devDependencies": {
     "@emotion/react": "^11.11.0",

--- a/src/app/components/LoginButton.tsx
+++ b/src/app/components/LoginButton.tsx
@@ -1,3 +1,22 @@
+/*
+ * Copyright (c) 2023 The Ontario Institute for Cancer Research. All rights reserved
+ *
+ * This program and the accompanying materials are made available under the terms of
+ * the GNU Affero General Public License v3.0. You should have received a copy of the
+ * GNU Affero General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 import urljoin from 'url-join';
 import { GoogleLogin } from '@icgc-argo/uikit';
 import { getAppConfig } from '@/global/config';

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -31,12 +31,14 @@ import ThemeProvider from './components/ThemeProvider';
 
 const workSans = Work_Sans({ subsets: ['latin'] });
 
+const queryClient = new QueryClient();
+
 export default function RootLayout({ children }: { children: ReactNode }) {
 	return (
 		<html lang="en">
 			<body className={workSans.className}>
 				<ThemeProvider>
-					<QueryClientProvider client={new QueryClient()}>
+					<QueryClientProvider client={queryClient}>
 						<AuthProvider>
 							<Header />
 							{children}

--- a/src/app/logging-in/page.tsx
+++ b/src/app/logging-in/page.tsx
@@ -27,7 +27,7 @@ import { EGO_JWT_KEY } from '@/global/constants';
 import { getAppConfig } from '@/global/config';
 import { useAuthContext } from '@/global/auth';
 
-export default async function CreatePage() {
+export default async function LoggedIn() {
 	const { EGO_CLIENT_ID, EGO_API_ROOT } = getAppConfig();
 	const egoLoginUrl = urljoin(EGO_API_ROOT, `/api/oauth/ego-token?client_id=${EGO_CLIENT_ID}`);
 	const { setEgoJwt } = useAuthContext();


### PR DESCRIPTION
Few small fixes I missed while reviewing PRs:
- add copyright to a file
- @emotion/styled should be peer dep so uikit compatibility works (this is noted in uikit readme)
- `react-query` client creation is in the render method of `layout` so will recreate on every layout render - moved outside of render loop
- renamed `CreatePage` to idiomatic component name
@demariadaniel the reason `platform-ui` uses "createPage" everywhere is because it's a function that augments a page component with a bunch of properties: https://github.com/icgc-argo/platform-ui/blob/faf11c923c54ee70c66b5d4a3c6264f923315fd2/global/utils/pages/index.tsx#L65