### PR TITLE
Clinical entity table

### DIFF
--- a/src/app/(post-login)/submission/program/[shortName]/clinical-data/ClinicalDataTableComp/index.tsx
+++ b/src/app/(post-login)/submission/program/[shortName]/clinical-data/ClinicalDataTableComp/index.tsx
@@ -37,7 +37,9 @@ const cellExpandToParent = css`
 	justify-content: flex-start;
 `;
 
-export const styleThickBorderString = `3px solid ${ARGOTheme.colors.grey}`;
+export const styleThickBorder = css`
+	border-right: 3px solid ${ARGOTheme.colors.grey};
+`;
 
 /**
  *
@@ -61,11 +63,13 @@ export const Cell = ({
 		:hover {
 			cursor: pointer;
 		}
-		border-right: ${isLastElement && styleThickBorderString};
+		${isLastElement && styleThickBorder};
 
 		${isSticky && stickyCSS}
 		${isSorted && `box-shadow: inset 0 ${isSorted === 'asc' ? '' : '-'}3px 0 0 rgb(7 116 211)`};
 		${cellExpandToParent}
+		height: 100%;
+		min-height: 28px;
 	`;
 
 	return <div css={[base, ...styles]}>{children}</div>;
@@ -88,7 +92,7 @@ export const TopLevelHeader = ({ title, styles = [] }) => {
 
 export const ClinicalCoreCompletionHeader = () => (
 	<>
-		<TopLevelHeader title="CLINICAL CORE COMPLETION" />
+		<TopLevelHeader title="CLINICAL CORE COMPLETION" styles={[styleThickBorder]} />
 		<div
 			css={css`
 				position: absolute;

--- a/src/app/(post-login)/submission/program/[shortName]/clinical-data/ClinicalDataTableComp/index.tsx
+++ b/src/app/(post-login)/submission/program/[shortName]/clinical-data/ClinicalDataTableComp/index.tsx
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2023 The Ontario Institute for Cancer Research. All rights reserved
+ *
+ * This program and the accompanying materials are made available under the terms of
+ * the GNU Affero General Public License v3.0. You should have received a copy of the
+ * GNU Affero General Public License along with this program.
+ *  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+ * SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+ * OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+import { ARGOTheme } from '@/app/hooks/ThemeProvider';
+import { css } from '@/lib/emotion';
+import { Icon, Tooltip } from '@icgc-argo/uikit';
+import { ReactNode } from 'react';
+
+const stickyCSS = css`
+	background-color: white;
+	left: 0;
+	position: sticky !important;
+	top: 0;
+	z-index: 1;
+`;
+
+const cellExpandToParent = css`
+	height: 28px;
+	display: flex;
+	align-items: center;
+	justify-content: flex-start;
+`;
+
+export const styleThickBorderString = `3px solid ${ARGOTheme.colors.grey}`;
+
+/**
+ *
+ * @param param0
+ * @returns
+ */
+export const Cell = ({
+	children,
+	config,
+	styles = [],
+}: {
+	children: ReactNode;
+	config: any;
+	styles?: any;
+}) => {
+	const { isLastElement, isSorted, isSticky } = config;
+	const base = css`
+		width: 100%;
+		padding: 2px 6px;
+		font-size: 12px;
+		:hover {
+			cursor: pointer;
+		}
+		border-right: ${isLastElement && styleThickBorderString};
+
+		${isSticky && stickyCSS}
+		${isSorted && `box-shadow: inset 0 ${isSorted === 'asc' ? '' : '-'}3px 0 0 rgb(7 116 211)`};
+		${cellExpandToParent}
+	`;
+
+	return <div css={[base, ...styles]}>{children}</div>;
+};
+
+export const TopLevelHeader = ({ title, styles = [] }) => {
+	const base = css`
+		background-color: ${ARGOTheme.colors.grey_4};
+		font-size: 13px;
+		padding: 5px;
+		text-align: left;
+		width: 100%;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+	`;
+
+	return <div css={[base, ...styles]}>{title}</div>;
+};
+
+export const ClinicalCoreCompletionHeader = () => (
+	<>
+		<TopLevelHeader title="CLINICAL CORE COMPLETION" />
+		<div
+			css={css`
+				position: absolute;
+				right: 8px;
+				top: 50%;
+				transform: translateY(-50%);
+			`}
+		>
+			<Tooltip
+				html={
+					<p
+						css={css`
+							margin: 0px;
+							margin-right: 6px;
+						`}
+					>
+						For clinical completeness, each donor requires: <br />
+						DO: at least one Donor record <br />
+						PD: at least one Primary Diagnosis record <br />
+						NS: all the registered Normal DNA Specimen record <br />
+						TS: all the registered Tumour DNA Specimen record <br />
+						TR: at least one Treatment record <br />
+						FO: at least one Follow Up record <br />
+					</p>
+				}
+			>
+				<Icon name="question_circle" fill="primary_2" width="18px" height="18px" />
+			</Tooltip>
+		</div>
+	</>
+);

--- a/src/app/(post-login)/submission/program/[shortName]/clinical-data/ClinicalDataTableComp/index.tsx
+++ b/src/app/(post-login)/submission/program/[shortName]/clinical-data/ClinicalDataTableComp/index.tsx
@@ -77,9 +77,6 @@ export const TopLevelHeader = ({ title, styles = [] }) => {
 		padding: 5px;
 		text-align: left;
 		width: 100%;
-		display: flex;
-		align-items: center;
-		justify-content: center;
 	`;
 
 	return <div css={[base, ...styles]}>{title}</div>;
@@ -87,7 +84,15 @@ export const TopLevelHeader = ({ title, styles = [] }) => {
 
 export const ClinicalCoreCompletionHeader = () => (
 	<>
-		<TopLevelHeader title="CLINICAL CORE COMPLETION" styles={[styleThickBorder]} />
+		<TopLevelHeader
+			title="CLINICAL CORE COMPLETION"
+			styles={[
+				styleThickBorder,
+				css`
+					text-align: center;
+				`,
+			]}
+		/>
 		<div
 			css={css`
 				position: absolute;

--- a/src/app/(post-login)/submission/program/[shortName]/clinical-data/ClinicalDataTableComp/index.tsx
+++ b/src/app/(post-login)/submission/program/[shortName]/clinical-data/ClinicalDataTableComp/index.tsx
@@ -50,7 +50,7 @@ export const Cell = ({
 	styles = [],
 }: {
 	children: ReactNode;
-	config: any;
+	config: { isLastElement?: boolean; isSorted?: string; isSticky?: boolean };
 	styles?: any;
 }) => {
 	const { isLastElement, isSorted, isSticky } = config;

--- a/src/app/(post-login)/submission/program/[shortName]/clinical-data/ClinicalDataTableComp/index.tsx
+++ b/src/app/(post-login)/submission/program/[shortName]/clinical-data/ClinicalDataTableComp/index.tsx
@@ -41,11 +41,6 @@ export const styleThickBorder = css`
 	border-right: 3px solid ${ARGOTheme.colors.grey};
 `;
 
-/**
- *
- * @param param0
- * @returns
- */
 export const Cell = ({
 	children,
 	config,

--- a/src/app/(post-login)/submission/program/[shortName]/clinical-data/ClinicalEntityDataTable.tsx
+++ b/src/app/(post-login)/submission/program/[shortName]/clinical-data/ClinicalEntityDataTable.tsx
@@ -780,31 +780,12 @@ const ClinicalEntityDataTable = ({
 						) : (
 							value
 						);
+
 						console.log('ss', style);
 						return (
 							<Cell config={{ isSticky }} styles={[style]}>
 								{content}
 							</Cell>
-						);
-
-						return (
-							<div
-								css={css`
-									font-size: 12px;
-									padding: 2px 8px;
-									min-width: 40px;
-									height: 28px;
-									border-right: 1px solid ${theme.colors.grey_2};
-									${isSticky && stickyCSS}
-									${cellExpandToParent}
-									height:100%;
-								`}
-								style={{
-									...style,
-								}}
-							>
-								{content}
-							</div>
 						);
 					},
 				})),

--- a/src/app/(post-login)/submission/program/[shortName]/clinical-data/ClinicalEntityDataTable.tsx
+++ b/src/app/(post-login)/submission/program/[shortName]/clinical-data/ClinicalEntityDataTable.tsx
@@ -638,13 +638,6 @@ const ClinicalEntityDataTable = ({
 			borderBottom: `1px solid ${theme.colors.grey_2}`,
 		};
 
-		const headerStyle = css`
-			background-color: ${theme.colors.grey_4};
-			font-size: 13px;
-			padding: 5px;
-			text-align: left;
-		`;
-
 		const stickyCSS = css`
 			background-color: white;
 			left: 0;
@@ -660,46 +653,64 @@ const ClinicalEntityDataTable = ({
 			justify-content: flex-start;
 		`;
 
+		const TopLevelHeader = ({ title }) => {
+			return (
+				<div
+					css={css`
+						background-color: ${theme.colors.grey_4};
+						font-size: 13px;
+						padding: 5px;
+						text-align: left;
+						width: 100%;
+						display: flex;
+						align-items: center;
+						justify-content: center;
+					`}
+				>
+					{title}
+				</div>
+			);
+		};
+
 		columns = [
 			{
 				id: 'clinical_core_completion_header',
 				meta: { customHeader: true },
 				sortingFn: sortEntityData,
-				header: (props) => {
+				header: () => {
 					return (
-						<div
-							css={css`
-								${headerStyle};
-								width: 100%;
-								display: flex;
-								align-items: center;
-								justify-content: center;
-								position: relative;
-							`}
-						>
-							CLINICAL CORE COMPLETION
-							<Tooltip
-								style={{ position: 'absolute', left: 'calc(100% - 20px)', top: '-2px' }}
-								html={
-									<p
-										css={css`
-											margin: 0px;
-											margin-right: 6px;
-										`}
-									>
-										For clinical completeness, each donor requires: <br />
-										DO: at least one Donor record <br />
-										PD: at least one Primary Diagnosis record <br />
-										NS: all the registered Normal DNA Specimen record <br />
-										TS: all the registered Tumour DNA Specimen record <br />
-										TR: at least one Treatment record <br />
-										FO: at least one Follow Up record <br />
-									</p>
-								}
+						<>
+							<TopLevelHeader title="CLINICAL CORE COMPLETION" />
+							<div
+								css={css`
+									position: absolute;
+									right: 8px;
+									top: 50%;
+									transform: translateY(-50%);
+								`}
 							>
-								<Icon name="question_circle" fill="primary_2" width="18px" height="18px" />
-							</Tooltip>
-						</div>
+								<Tooltip
+									html={
+										<p
+											css={css`
+												margin: 0px;
+												margin-right: 6px;
+											`}
+										>
+											For clinical completeness, each donor requires: <br />
+											DO: at least one Donor record <br />
+											PD: at least one Primary Diagnosis record <br />
+											NS: all the registered Normal DNA Specimen record <br />
+											TS: all the registered Tumour DNA Specimen record <br />
+											TR: at least one Treatment record <br />
+											FO: at least one Follow Up record <br />
+										</p>
+									}
+								>
+									<Icon name="question_circle" fill="primary_2" width="18px" height="18px" />
+								</Tooltip>
+							</div>
+						</>
 					);
 				},
 				headerStyle: completionHeaderStyle,
@@ -780,16 +791,7 @@ const ClinicalEntityDataTable = ({
 			{
 				id: 'submitted_donor_data_header',
 				meta: { customHeader: true },
-				header: (props) => (
-					<div
-						css={css`
-							width: 100%;
-							${headerStyle}
-						`}
-					>
-						SUBMITTED DONOR DATA
-					</div>
-				),
+				header: () => <TopLevelHeader title="SUBMITTED DONOR DATA" />,
 				headerStyle: dataHeaderStyle,
 				columns: columns.slice(7),
 			},

--- a/src/app/(post-login)/submission/program/[shortName]/clinical-data/ClinicalEntityDataTable.tsx
+++ b/src/app/(post-login)/submission/program/[shortName]/clinical-data/ClinicalEntityDataTable.tsx
@@ -32,14 +32,19 @@ import {
 	Link,
 	NOTIFICATION_VARIANTS,
 	Table,
-	Tooltip,
 	Typography,
 	css,
 	useTheme,
 } from '@icgc-argo/uikit';
 import memoize from 'lodash/memoize';
-import { ReactNode, createRef, useEffect, useState } from 'react';
+import { createRef, useEffect, useState } from 'react';
 import urljoin from 'url-join';
+import {
+	Cell,
+	ClinicalCoreCompletionHeader,
+	TopLevelHeader,
+	styleThickBorderString,
+} from './ClinicalDataTableComp';
 import {
 	ClinicalEntitySearchResultResponse,
 	CompletionStates,
@@ -475,8 +480,6 @@ const ClinicalEntityDataTable = ({
 			.sort(sortEntityData);
 	}
 
-	const styleThickBorderString = `3px solid ${theme.colors.grey}`;
-
 	const getHeaderBorder = (key) =>
 		(showCompletionStats && key === completionColumnHeaders.followUps) ||
 		(!showCompletionStats && key === 'donor_id') ||
@@ -627,103 +630,6 @@ const ClinicalEntityDataTable = ({
 	});
 
 	if (showCompletionStats) {
-		const stickyCSS = css`
-			background-color: white;
-			left: 0;
-			position: sticky !important;
-			top: 0;
-			z-index: 1;
-		`;
-
-		const cellExpandToParent = css`
-			height: 28px;
-			display: flex;
-			align-items: center;
-			justify-content: flex-start;
-		`;
-
-		const TopLevelHeader = ({ title, styles = [] }) => {
-			const base = css`
-				background-color: ${theme.colors.grey_4};
-				font-size: 13px;
-				padding: 5px;
-				text-align: left;
-				width: 100%;
-				display: flex;
-				align-items: center;
-				justify-content: center;
-			`;
-
-			return <div css={[base, ...styles]}>{title}</div>;
-		};
-
-		const ClinicalCoreCompletionHeader = () => (
-			<>
-				<TopLevelHeader title="CLINICAL CORE COMPLETION" />
-				<div
-					css={css`
-						position: absolute;
-						right: 8px;
-						top: 50%;
-						transform: translateY(-50%);
-					`}
-				>
-					<Tooltip
-						html={
-							<p
-								css={css`
-									margin: 0px;
-									margin-right: 6px;
-								`}
-							>
-								For clinical completeness, each donor requires: <br />
-								DO: at least one Donor record <br />
-								PD: at least one Primary Diagnosis record <br />
-								NS: all the registered Normal DNA Specimen record <br />
-								TS: all the registered Tumour DNA Specimen record <br />
-								TR: at least one Treatment record <br />
-								FO: at least one Follow Up record <br />
-							</p>
-						}
-					>
-						<Icon name="question_circle" fill="primary_2" width="18px" height="18px" />
-					</Tooltip>
-				</div>
-			</>
-		);
-
-		/**
-		 *
-		 * @param param0
-		 * @returns
-		 */
-		const Cell = ({
-			children,
-			config,
-			styles = [],
-		}: {
-			children: ReactNode;
-			config: any;
-			styles?: any;
-		}) => {
-			const { isLastElement, isSorted, isSticky } = config;
-			const base = css`
-				width: 100%;
-				padding: 2px 6px;
-				font-size: 12px;
-				:hover {
-					cursor: pointer;
-				}
-				border-right: ${isLastElement && styleThickBorderString};
-
-				${isSticky && stickyCSS}
-				${isSorted && `box-shadow: inset 0 ${isSorted === 'asc' ? '' : '-'}3px 0 0 rgb(7 116 211)`};
-				${cellExpandToParent}
-			`;
-
-			return <div css={[base, ...styles]}>{children}</div>;
-		};
-
 		columns = [
 			{
 				id: 'clinical_core_completion_header',

--- a/src/app/(post-login)/submission/program/[shortName]/clinical-data/ClinicalEntityDataTable.tsx
+++ b/src/app/(post-login)/submission/program/[shortName]/clinical-data/ClinicalEntityDataTable.tsx
@@ -635,11 +635,6 @@ const ClinicalEntityDataTable = ({
 			paddingLeft: '6px',
 		};
 
-		const noDataCellStyle = {
-			height: 50,
-			borderBottom: `1px solid ${theme.colors.grey_2}`,
-		};
-
 		const stickyCSS = css`
 			background-color: white;
 			left: 0;
@@ -760,8 +755,6 @@ const ClinicalEntityDataTable = ({
 
 						return <Cell config={{ isLastElement, isSorted, isSticky }}>{value}</Cell>;
 					},
-					maxWidth: noTableData ? 50 : 250,
-					style: noTableData ? noDataCellStyle : {},
 					meta: { customCell: true, customHeader: true },
 					cell: (context) => {
 						const value = context.getValue();
@@ -781,7 +774,6 @@ const ClinicalEntityDataTable = ({
 							value
 						);
 
-						console.log('ss', style);
 						return (
 							<Cell config={{ isSticky }} styles={[style]}>
 								{content}

--- a/src/app/(post-login)/submission/program/[shortName]/clinical-data/ClinicalEntityDataTable.tsx
+++ b/src/app/(post-login)/submission/program/[shortName]/clinical-data/ClinicalEntityDataTable.tsx
@@ -764,8 +764,8 @@ const ClinicalEntityDataTable = ({
 									height: 28px;
 									border-right: 1px solid ${theme.colors.grey_2};
 									${isSticky && stickyCSS}
-									height:100%;
 									${cellExpandToParent}
+									height:100%;
 								`}
 								style={{
 									...style,

--- a/src/app/(post-login)/submission/program/[shortName]/clinical-data/ClinicalEntityDataTable.tsx
+++ b/src/app/(post-login)/submission/program/[shortName]/clinical-data/ClinicalEntityDataTable.tsx
@@ -672,47 +672,47 @@ const ClinicalEntityDataTable = ({
 			);
 		};
 
+		const ClinicalCoreCompletionHeader = () => (
+			<>
+				<TopLevelHeader title="CLINICAL CORE COMPLETION" />
+				<div
+					css={css`
+						position: absolute;
+						right: 8px;
+						top: 50%;
+						transform: translateY(-50%);
+					`}
+				>
+					<Tooltip
+						html={
+							<p
+								css={css`
+									margin: 0px;
+									margin-right: 6px;
+								`}
+							>
+								For clinical completeness, each donor requires: <br />
+								DO: at least one Donor record <br />
+								PD: at least one Primary Diagnosis record <br />
+								NS: all the registered Normal DNA Specimen record <br />
+								TS: all the registered Tumour DNA Specimen record <br />
+								TR: at least one Treatment record <br />
+								FO: at least one Follow Up record <br />
+							</p>
+						}
+					>
+						<Icon name="question_circle" fill="primary_2" width="18px" height="18px" />
+					</Tooltip>
+				</div>
+			</>
+		);
+
 		columns = [
 			{
 				id: 'clinical_core_completion_header',
 				meta: { customHeader: true },
 				sortingFn: sortEntityData,
-				header: () => {
-					return (
-						<>
-							<TopLevelHeader title="CLINICAL CORE COMPLETION" />
-							<div
-								css={css`
-									position: absolute;
-									right: 8px;
-									top: 50%;
-									transform: translateY(-50%);
-								`}
-							>
-								<Tooltip
-									html={
-										<p
-											css={css`
-												margin: 0px;
-												margin-right: 6px;
-											`}
-										>
-											For clinical completeness, each donor requires: <br />
-											DO: at least one Donor record <br />
-											PD: at least one Primary Diagnosis record <br />
-											NS: all the registered Normal DNA Specimen record <br />
-											TS: all the registered Tumour DNA Specimen record <br />
-											TR: at least one Treatment record <br />
-											FO: at least one Follow Up record <br />
-										</p>
-									}
-								>
-									<Icon name="question_circle" fill="primary_2" width="18px" height="18px" />
-								</Tooltip>
-							</div>
-						</>
-					);
-				},
+				header: () => <ClinicalCoreCompletionHeader />,
 				headerStyle: completionHeaderStyle,
 				columns: columns.slice(0, 7).map((column, index) => ({
 					...column,

--- a/src/app/(post-login)/submission/program/[shortName]/clinical-data/ClinicalEntityDataTable.tsx
+++ b/src/app/(post-login)/submission/program/[shortName]/clinical-data/ClinicalEntityDataTable.tsx
@@ -582,10 +582,7 @@ const ClinicalEntityDataTable = ({
 			background: white,
 			position: absolute,
 		`;
-		const headerDOStyle = css`
-			margin-left: ${stickyDonorIDColumnsWidth};
-		`;
-		const headerProgramIdStyle = css`
+		const stickyMarginStyle = css`
 			margin-left: ${stickyDonorIDColumnsWidth};
 		`;
 		const style = css`
@@ -593,8 +590,8 @@ const ClinicalEntityDataTable = ({
 			background: ${errorState && theme.colors.error_4};
 			borderright: ${border};
 			${column.Header === 'donor_id' && headerDonorIdStyle};
-			${column.Header === 'DO' && headerDOStyle};
-			${column.Header === 'program_id' && !showCompletionStats && headerProgramIdStyle};
+			${column.Header === 'DO' && stickyMarginStyle};
+			${column.Header === 'program_id' && !showCompletionStats && stickyMarginStyle};
 		`;
 
 		return {
@@ -630,11 +627,6 @@ const ClinicalEntityDataTable = ({
 	});
 
 	if (showCompletionStats) {
-		const dataHeaderStyle = {
-			textAlign: 'left',
-			paddingLeft: '6px',
-		};
-
 		const stickyCSS = css`
 			background-color: white;
 			left: 0;
@@ -650,23 +642,19 @@ const ClinicalEntityDataTable = ({
 			justify-content: flex-start;
 		`;
 
-		const TopLevelHeader = ({ title }) => {
-			return (
-				<div
-					css={css`
-						background-color: ${theme.colors.grey_4};
-						font-size: 13px;
-						padding: 5px;
-						text-align: left;
-						width: 100%;
-						display: flex;
-						align-items: center;
-						justify-content: center;
-					`}
-				>
-					{title}
-				</div>
-			);
+		const TopLevelHeader = ({ title, styles = [] }) => {
+			const base = css`
+				background-color: ${theme.colors.grey_4};
+				font-size: 13px;
+				padding: 5px;
+				text-align: left;
+				width: 100%;
+				display: flex;
+				align-items: center;
+				justify-content: center;
+			`;
+
+			return <div css={[base, ...styles]}>{title}</div>;
 		};
 
 		const ClinicalCoreCompletionHeader = () => (
@@ -732,7 +720,7 @@ const ClinicalEntityDataTable = ({
 				${isSorted && `box-shadow: inset 0 ${isSorted === 'asc' ? '' : '-'}3px 0 0 rgb(7 116 211)`};
 				${cellExpandToParent}
 			`;
-			console.log('s', styles);
+
 			return <div css={[base, ...styles]}>{children}</div>;
 		};
 
@@ -785,8 +773,16 @@ const ClinicalEntityDataTable = ({
 			{
 				id: 'submitted_donor_data_header',
 				meta: { customHeader: true },
-				header: () => <TopLevelHeader title="SUBMITTED DONOR DATA" />,
-				headerStyle: dataHeaderStyle,
+				header: () => (
+					<TopLevelHeader
+						title="SUBMITTED DONOR DATA"
+						styles={[
+							css`
+								text-align: left;
+							`,
+						]}
+					/>
+				),
 				columns: columns.slice(7),
 			},
 		];

--- a/src/app/(post-login)/submission/program/[shortName]/clinical-data/ClinicalEntityDataTable.tsx
+++ b/src/app/(post-login)/submission/program/[shortName]/clinical-data/ClinicalEntityDataTable.tsx
@@ -476,6 +476,7 @@ const ClinicalEntityDataTable = ({
 	}
 
 	const styleThickBorderString = `3px solid ${theme.colors.grey}`;
+
 	const getHeaderBorder = (key) =>
 		(showCompletionStats && key === completionColumnHeaders.followUps) ||
 		(!showCompletionStats && key === 'donor_id') ||
@@ -707,13 +708,37 @@ const ClinicalEntityDataTable = ({
 			</>
 		);
 
+		const SubLevelHeader = ({ value, config }) => {
+			const { isLastElement, isSorted, isSticky } = config;
+			return (
+				<div
+					css={css`
+						width: 100%;
+						padding: 2px 6px;
+						font-size: 12px;
+						:hover {
+							cursor: pointer;
+						}
+						border-right: ${isLastElement && styleThickBorderString};
+
+						${isSticky && stickyCSS}
+						${isSorted &&
+						`box-shadow: inset 0 ${isSorted === 'asc' ? '' : '-'}3px 0 0 rgb(7 116 211)`};
+						${cellExpandToParent}
+					`}
+				>
+					{value}
+				</div>
+			);
+		};
+
 		columns = [
 			{
 				id: 'clinical_core_completion_header',
 				meta: { customHeader: true },
 				sortingFn: sortEntityData,
 				header: () => <ClinicalCoreCompletionHeader />,
-				headerStyle: completionHeaderStyle,
+
 				columns: columns.slice(0, 7).map((column, index) => ({
 					...column,
 					sortingFn: sortEntityData,
@@ -724,26 +749,7 @@ const ClinicalEntityDataTable = ({
 						const isSticky = value === 'donor_id';
 						const isSorted = props.sorted;
 
-						return (
-							<div
-								css={css`
-									width: 100%;
-									padding: 2px 6px;
-									font-size: 12px;
-									:hover {
-										cursor: pointer;
-									}
-									border-right: ${isLastElement && styleThickBorderString};
-
-									${isSticky && stickyCSS}
-									${isSorted &&
-									`box-shadow: inset 0 ${isSorted === 'asc' ? '' : '-'}3px 0 0 rgb(7 116 211)`};
-									${cellExpandToParent}
-								`}
-							>
-								{value}
-							</div>
-						);
+						return <SubLevelHeader value={value} config={{ isLastElement, isSorted, isSticky }} />;
 					},
 					maxWidth: noTableData ? 50 : 250,
 					style: noTableData ? noDataCellStyle : {},

--- a/src/app/(post-login)/submission/program/[shortName]/clinical-data/ClinicalEntityDataTable.tsx
+++ b/src/app/(post-login)/submission/program/[shortName]/clinical-data/ClinicalEntityDataTable.tsx
@@ -640,8 +640,6 @@ const ClinicalEntityDataTable = ({
 
 		const headerStyle = css`
 			background-color: ${theme.colors.grey_4};
-			border-bottom: 1px solid ${theme.colors.grey_2};
-			border-right: 1px solid ${theme.colors.grey_2};
 			font-size: 13px;
 			padding: 5px;
 			text-align: left;
@@ -655,6 +653,13 @@ const ClinicalEntityDataTable = ({
 			z-index: 1;
 		`;
 
+		const cellExpandToParent = css`
+			height: 28px;
+			display: flex;
+			align-items: center;
+			justify-content: flex-start;
+		`;
+
 		columns = [
 			{
 				id: 'clinical_core_completion_header',
@@ -662,45 +667,39 @@ const ClinicalEntityDataTable = ({
 				sortingFn: sortEntityData,
 				header: (props) => {
 					return (
-						<th
-							colSpan={props.colSpan}
+						<div
 							css={css`
 								${headerStyle};
-								border-right: 3px solid ${theme.colors.grey};
+								width: 100%;
+								display: flex;
+								align-items: center;
+								justify-content: center;
+								position: relative;
 							`}
 						>
-							<div
-								css={css`
-									display: flex;
-									align-items: center;
-									justify-content: center;
-									position: relative;
-								`}
+							CLINICAL CORE COMPLETION
+							<Tooltip
+								style={{ position: 'absolute', left: 'calc(100% - 20px)', top: '-2px' }}
+								html={
+									<p
+										css={css`
+											margin: 0px;
+											margin-right: 6px;
+										`}
+									>
+										For clinical completeness, each donor requires: <br />
+										DO: at least one Donor record <br />
+										PD: at least one Primary Diagnosis record <br />
+										NS: all the registered Normal DNA Specimen record <br />
+										TS: all the registered Tumour DNA Specimen record <br />
+										TR: at least one Treatment record <br />
+										FO: at least one Follow Up record <br />
+									</p>
+								}
 							>
-								CLINICAL CORE COMPLETION
-								<Tooltip
-									style={{ position: 'absolute', left: 'calc(100% - 20px)', top: '-2px' }}
-									html={
-										<p
-											css={css`
-												margin: 0px;
-												margin-right: 6px;
-											`}
-										>
-											For clinical completeness, each donor requires: <br />
-											DO: at least one Donor record <br />
-											PD: at least one Primary Diagnosis record <br />
-											NS: all the registered Normal DNA Specimen record <br />
-											TS: all the registered Tumour DNA Specimen record <br />
-											TR: at least one Treatment record <br />
-											FO: at least one Follow Up record <br />
-										</p>
-									}
-								>
-									<Icon name="question_circle" fill="primary_2" width="18px" height="18px" />
-								</Tooltip>
-							</div>
-						</th>
+								<Icon name="question_circle" fill="primary_2" width="18px" height="18px" />
+							</Tooltip>
+						</div>
 					);
 				},
 				headerStyle: completionHeaderStyle,
@@ -715,25 +714,24 @@ const ClinicalEntityDataTable = ({
 						const isSorted = props.sorted;
 
 						return (
-							<th
-								onClick={props.getSortingHandler()}
+							<div
 								css={css`
+									width: 100%;
 									padding: 2px 6px;
 									font-size: 12px;
 									:hover {
 										cursor: pointer;
 									}
-									border-bottom: 1px solid ${theme.colors.grey_2};
-									border-right: ${isLastElement
-										? styleThickBorderString
-										: `1px solid ${theme.colors.grey_2}`};
+									border-right: ${isLastElement && styleThickBorderString};
+
 									${isSticky && stickyCSS}
 									${isSorted &&
 									`box-shadow: inset 0 ${isSorted === 'asc' ? '' : '-'}3px 0 0 rgb(7 116 211)`};
+									${cellExpandToParent}
 								`}
 							>
 								{value}
-							</th>
+							</div>
 						);
 					},
 					maxWidth: noTableData ? 50 : 250,
@@ -758,26 +756,23 @@ const ClinicalEntityDataTable = ({
 						);
 
 						return (
-							<td
+							<div
 								css={css`
+									font-size: 12px;
+									padding: 2px 8px;
+									min-width: 40px;
+									height: 28px;
 									border-right: 1px solid ${theme.colors.grey_2};
 									${isSticky && stickyCSS}
+									height:100%;
+									${cellExpandToParent}
 								`}
 								style={{
 									...style,
 								}}
 							>
-								<div
-									css={css`
-										font-size: 12px;
-										padding: 2px 8px;
-										min-width: 40px;
-										height: 28px;
-									`}
-								>
-									{content}
-								</div>
-							</td>
+								{content}
+							</div>
 						);
 					},
 				})),
@@ -786,9 +781,14 @@ const ClinicalEntityDataTable = ({
 				id: 'submitted_donor_data_header',
 				meta: { customHeader: true },
 				header: (props) => (
-					<th colSpan={props.colSpan} css={headerStyle}>
-						<div>SUBMITTED DONOR DATA</div>
-					</th>
+					<div
+						css={css`
+							width: 100%;
+							${headerStyle}
+						`}
+					>
+						SUBMITTED DONOR DATA
+					</div>
 				),
 				headerStyle: dataHeaderStyle,
 				columns: columns.slice(7),

--- a/src/app/(post-login)/submission/program/[shortName]/clinical-data/ClinicalEntityDataTable.tsx
+++ b/src/app/(post-login)/submission/program/[shortName]/clinical-data/ClinicalEntityDataTable.tsx
@@ -43,7 +43,7 @@ import {
 	Cell,
 	ClinicalCoreCompletionHeader,
 	TopLevelHeader,
-	styleThickBorderString,
+	styleThickBorder,
 } from './ClinicalDataTableComp';
 import {
 	ClinicalEntitySearchResultResponse,
@@ -484,7 +484,7 @@ const ClinicalEntityDataTable = ({
 		(showCompletionStats && key === completionColumnHeaders.followUps) ||
 		(!showCompletionStats && key === 'donor_id') ||
 		key === 'FO'
-			? styleThickBorderString
+			? styleThickBorder
 			: '';
 
 	const [stickyDonorIDColumnsWidth, setStickyDonorIDColumnsWidth] = useState(74);
@@ -578,8 +578,6 @@ const ClinicalEntityDataTable = ({
 			specificErrorValue?.length > 0 ||
 			fieldError?.length > 0;
 
-		const border = getHeaderBorder(id);
-
 		// use Emotion styling
 		const headerDonorIdStyle = css`
 			background: white,
@@ -591,7 +589,7 @@ const ClinicalEntityDataTable = ({
 		const style = css`
 			color: ${isCompletionCell && !errorState && theme.colors.accent1_dark};
 			background: ${errorState && theme.colors.error_4};
-			borderright: ${border};
+			${getHeaderBorder(id)}
 			${column.Header === 'donor_id' && headerDonorIdStyle};
 			${column.Header === 'DO' && stickyMarginStyle};
 			${column.Header === 'program_id' && !showCompletionStats && stickyMarginStyle};

--- a/src/app/(post-login)/submission/program/[shortName]/clinical-data/ClinicalEntityDataTable.tsx
+++ b/src/app/(post-login)/submission/program/[shortName]/clinical-data/ClinicalEntityDataTable.tsx
@@ -607,22 +607,6 @@ const ClinicalEntityDataTable = ({
 			id: key,
 			accessorKey: key,
 			Header: key,
-			headerStyle: {
-				borderRight: getHeaderBorder(key),
-				...(key === 'donor_id' && {
-					position: 'absolute',
-					//z-index used here because header element is beneath its neighbouring element.
-					zIndex: 1,
-					background: 'white',
-				}),
-				...(key === 'DO' && {
-					marginLeft: stickyDonorIDColumnsWidth,
-				}),
-				...(key === 'program_id' &&
-					!showCompletionStats && {
-						marginLeft: stickyDonorIDColumnsWidth,
-					}),
-			},
 			minWidth: getColumnWidth(key, showCompletionStats, noTableData),
 		};
 	});

--- a/src/app/(post-login)/submission/program/[shortName]/clinical-data/ClinicalEntityDataTable.tsx
+++ b/src/app/(post-login)/submission/program/[shortName]/clinical-data/ClinicalEntityDataTable.tsx
@@ -38,7 +38,7 @@ import {
 	useTheme,
 } from '@icgc-argo/uikit';
 import memoize from 'lodash/memoize';
-import { createRef, useEffect, useState } from 'react';
+import { ReactNode, createRef, useEffect, useState } from 'react';
 import urljoin from 'url-join';
 import {
 	ClinicalEntitySearchResultResponse,
@@ -577,23 +577,28 @@ const ClinicalEntityDataTable = ({
 
 		const border = getHeaderBorder(id);
 
+		// use Emotion styling
+		const headerDonorIdStyle = css`
+			background: white,
+			position: absolute,
+		`;
+		const headerDOStyle = css`
+			margin-left: ${stickyDonorIDColumnsWidth};
+		`;
+		const headerProgramIdStyle = css`
+			margin-left: ${stickyDonorIDColumnsWidth};
+		`;
+		const style = css`
+			color: ${isCompletionCell && !errorState && theme.colors.accent1_dark};
+			background: ${errorState && theme.colors.error_4};
+			borderright: ${border};
+			${column.Header === 'donor_id' && headerDonorIdStyle};
+			${column.Header === 'DO' && headerDOStyle};
+			${column.Header === 'program_id' && !showCompletionStats && headerProgramIdStyle};
+		`;
+
 		return {
-			style: {
-				color: isCompletionCell && !errorState ? theme.colors.accent1_dark : '',
-				background: errorState ? theme.colors.error_4 : '',
-				borderRight: border,
-				...(column.Header === 'donor_id' && {
-					background: 'white',
-					position: 'absolute',
-				}),
-				...(column.Header === 'DO' && {
-					marginLeft: stickyDonorIDColumnsWidth,
-				}),
-				...(column.Header === 'program_id' &&
-					!showCompletionStats && {
-						marginLeft: stickyDonorIDColumnsWidth,
-					}),
-			},
+			style,
 			isCompletionCell,
 			errorState,
 		};
@@ -625,10 +630,6 @@ const ClinicalEntityDataTable = ({
 	});
 
 	if (showCompletionStats) {
-		const completionHeaderStyle = {
-			borderRight: getHeaderBorder(completionColumnHeaders.followUps),
-		};
-
 		const dataHeaderStyle = {
 			textAlign: 'left',
 			paddingLeft: '6px',
@@ -708,28 +709,36 @@ const ClinicalEntityDataTable = ({
 			</>
 		);
 
-		const SubLevelHeader = ({ value, config }) => {
+		/**
+		 *
+		 * @param param0
+		 * @returns
+		 */
+		const Cell = ({
+			children,
+			config,
+			styles = [],
+		}: {
+			children: ReactNode;
+			config: any;
+			styles?: any;
+		}) => {
 			const { isLastElement, isSorted, isSticky } = config;
-			return (
-				<div
-					css={css`
-						width: 100%;
-						padding: 2px 6px;
-						font-size: 12px;
-						:hover {
-							cursor: pointer;
-						}
-						border-right: ${isLastElement && styleThickBorderString};
+			const base = css`
+				width: 100%;
+				padding: 2px 6px;
+				font-size: 12px;
+				:hover {
+					cursor: pointer;
+				}
+				border-right: ${isLastElement && styleThickBorderString};
 
-						${isSticky && stickyCSS}
-						${isSorted &&
-						`box-shadow: inset 0 ${isSorted === 'asc' ? '' : '-'}3px 0 0 rgb(7 116 211)`};
-						${cellExpandToParent}
-					`}
-				>
-					{value}
-				</div>
-			);
+				${isSticky && stickyCSS}
+				${isSorted && `box-shadow: inset 0 ${isSorted === 'asc' ? '' : '-'}3px 0 0 rgb(7 116 211)`};
+				${cellExpandToParent}
+			`;
+			console.log('s', styles);
+			return <div css={[base, ...styles]}>{children}</div>;
 		};
 
 		columns = [
@@ -749,7 +758,7 @@ const ClinicalEntityDataTable = ({
 						const isSticky = value === 'donor_id';
 						const isSorted = props.sorted;
 
-						return <SubLevelHeader value={value} config={{ isLastElement, isSorted, isSticky }} />;
+						return <Cell config={{ isLastElement, isSorted, isSticky }}>{value}</Cell>;
 					},
 					maxWidth: noTableData ? 50 : 250,
 					style: noTableData ? noDataCellStyle : {},
@@ -770,6 +779,12 @@ const ClinicalEntityDataTable = ({
 							<Icon name="checkmark" fill="accent1_dimmed" width="12px" height="12px" />
 						) : (
 							value
+						);
+						console.log('ss', style);
+						return (
+							<Cell config={{ isSticky }} styles={[style]}>
+								{content}
+							</Cell>
 						);
 
 						return (

--- a/src/app/hooks/ThemeProvider.tsx
+++ b/src/app/hooks/ThemeProvider.tsx
@@ -33,6 +33,8 @@ const typography = mapValues(defaultTheme.typography, (typography) => ({
 }));
 const theme = { ...defaultTheme, typography };
 
+export const ARGOTheme = defaultTheme;
+
 export default function ThemeProvider({ children }: { children: React.ReactNode }) {
 	return (
 		<>


### PR DESCRIPTION
NB: not everything here is perfect. it's a step. an improvement. the main logic in the file is still in need of work, so let's focus on the big picture. 

- uses uikit v3 keeping in line with other styling in platform-ui
- any "noData" styling is removed, we don't even render table if there's no data
- moves some styling into it's own file, slowly cleaning up the crowded clinicalEntityTable file
- uses Theme object directly. We do not or do we intend to use dynamic theming in this project. Most of the project would require an overhaul on styling if we ever decided to do this.
- clean up deeply nested confusing logic for styling
- removes some of the resizer style until the logic can be cleaned up / fixed. broken in platform-ui prod.
- cleans up styling
  - minimizes mixture of styling approaches 
  - uses Emotion `css` vs inline style vs table component (eg. `headerStyle`) as much as possible 