### PR TITLE
Register Samples: page fixes

### DIFF
--- a/src/app/(post-login)/submission/program/[shortName]/sample-registration/components/RegisterSampleModal.tsx
+++ b/src/app/(post-login)/submission/program/[shortName]/sample-registration/components/RegisterSampleModal.tsx
@@ -22,13 +22,13 @@ import COMMIT_CLINICAL_REGISTRATION_MUTATION from '@/app/gql/clinical/COMMIT_CLI
 import GET_REGISTRATION_QUERY from '@/app/gql/clinical/GET_REGISTRATION_QUERY';
 import { useGlobalLoader } from '@/app/hooks/GlobalLoaderProvider';
 import { useToaster } from '@/app/hooks/ToastProvider';
+import { useClinicalMutation } from '@/app/hooks/useApolloQuery';
 import {
 	CONTACT_PAGE_PATH,
 	PROGRAM_DASHBOARD_PATH,
 	PROGRAM_SHORT_NAME_PATH,
 } from '@/global/constants';
 import { sleep } from '@/global/utils';
-import { useMutation } from '@apollo/client';
 import { Modal, TOAST_VARIANTS, Typography, Link as UIKitLink } from '@icgc-argo/uikit';
 import { get } from 'lodash';
 import Link from 'next/link';
@@ -44,7 +44,7 @@ export default function RegisterSamplesModal({
 	shortName: string;
 	registrationId: string;
 }) {
-	const [commitRegistration] = useMutation(COMMIT_CLINICAL_REGISTRATION_MUTATION, {
+	const [commitRegistration] = useClinicalMutation(COMMIT_CLINICAL_REGISTRATION_MUTATION, {
 		variables: {
 			shortName,
 			registrationId,

--- a/src/app/(post-login)/submission/program/[shortName]/sample-registration/page.tsx
+++ b/src/app/(post-login)/submission/program/[shortName]/sample-registration/page.tsx
@@ -31,14 +31,13 @@ import GET_REGISTRATION_QUERY from '@/app/gql/clinical/GET_REGISTRATION_QUERY';
 import { useAppConfigContext } from '@/app/hooks/AppProvider';
 import { useAuthContext } from '@/app/hooks/AuthProvider';
 import { useToaster } from '@/app/hooks/ToastProvider';
-import { useClinicalQuery } from '@/app/hooks/useApolloQuery';
+import { useClinicalMutation, useClinicalQuery } from '@/app/hooks/useApolloQuery';
 import useCommonToasters from '@/app/hooks/useCommonToasters';
 import { useSubmissionSystemStatus } from '@/app/hooks/useSubmissionSystemStatus';
 import { UPLOAD_REGISTRATION } from '@/global/constants';
 import { getProgramPath, notNull } from '@/global/utils';
 import { createFileFormData, uploadFileRequest } from '@/global/utils/form';
 import { css } from '@/lib/emotion';
-import { useMutation as useGQLMutation, useQuery } from '@apollo/client';
 import {
 	BUTTON_SIZES,
 	BUTTON_VARIANTS,
@@ -62,7 +61,7 @@ const Register = ({ shortName }: { shortName: string }) => {
 		data,
 		refetch,
 		updateQuery: updateClinicalRegistrationQuery,
-	} = useQuery(GET_REGISTRATION_QUERY, {
+	} = useClinicalQuery(GET_REGISTRATION_QUERY, {
 		variables: { shortName },
 	});
 
@@ -108,7 +107,7 @@ const Register = ({ shortName }: { shortName: string }) => {
 			return uploadFileRequest(uploadURL, formData, egoJwt);
 		},
 		{
-			onSuccess: (data, variables, context) => console.log(data),
+			onSuccess: (data, variables, context) => refetch(),
 
 			onError: () => {
 				commonToaster.unknownError();
@@ -126,7 +125,7 @@ const Register = ({ shortName }: { shortName: string }) => {
 	};
 
 	// file preview clear
-	const [clearRegistration] = useGQLMutation(CLEAR_CLINICAL_REGISTRATION_MUTATION);
+	const [clearRegistration] = useClinicalMutation(CLEAR_CLINICAL_REGISTRATION_MUTATION);
 	const handleClearClick = async () => {
 		if (clinicalRegistration?.id == null) {
 			refetch();
@@ -143,6 +142,7 @@ const Register = ({ shortName }: { shortName: string }) => {
 			await refetch();
 		} catch (err) {
 			await refetch();
+			console.log(err);
 			toaster.addToast({
 				variant: 'ERROR',
 				title: 'Something went wrong',

--- a/src/app/(post-login)/submission/program/[shortName]/sample-registration/page.tsx
+++ b/src/app/(post-login)/submission/program/[shortName]/sample-registration/page.tsx
@@ -102,12 +102,14 @@ const Register = ({ shortName }: { shortName: string }) => {
 	const registrationId = get(clinicalRegistration, 'id', '') || '';
 
 	// handlers
+	const uploadURL = urlJoin(CLINICAL_API_ROOT, getProgramPath(UPLOAD_REGISTRATION, shortName));
 	const uploadFile = useMutation(
 		(formData) => {
-			const url = urlJoin(CLINICAL_API_ROOT, getProgramPath(UPLOAD_REGISTRATION, shortName));
-			return uploadFileRequest(url, formData, egoJwt);
+			return uploadFileRequest(uploadURL, formData, egoJwt);
 		},
 		{
+			onSuccess: (data, variables, context) => console.log(data),
+
 			onError: () => {
 				commonToaster.unknownError();
 			},
@@ -204,7 +206,11 @@ const Register = ({ shortName }: { shortName: string }) => {
 							flags={instructionFlags}
 						/>
 					</Container>
-					<Container>
+					<Container
+						css={css`
+							flex: 1;
+						`}
+					>
 						{fileErrors.filter(notNull).map((fileError, index) => (
 							<FileError
 								fileError={{

--- a/src/app/(post-login)/submission/program/[shortName]/sample-registration/page.tsx
+++ b/src/app/(post-login)/submission/program/[shortName]/sample-registration/page.tsx
@@ -142,7 +142,6 @@ const Register = ({ shortName }: { shortName: string }) => {
 			await refetch();
 		} catch (err) {
 			await refetch();
-			console.log(err);
 			toaster.addToast({
 				variant: 'ERROR',
 				title: 'Something went wrong',

--- a/src/app/hooks/useApolloQuery.tsx
+++ b/src/app/hooks/useApolloQuery.tsx
@@ -23,13 +23,18 @@ import {
 	QueryHookOptions,
 	QueryResult,
 	TypedDocumentNode,
+	useMutation,
 	useQuery,
 } from '@apollo/client';
 
+type APIType = keyof typeof apiName;
+type QueryType<TData, TVariables> = DocumentNode | TypedDocumentNode<TData, TVariables>;
+type OptionsType = QueryHookOptions<any, OperationVariables> | undefined;
+
 const useApolloQuery = <TData, TVariables>(
-	query: DocumentNode | TypedDocumentNode<TData, TVariables>,
-	api: keyof typeof apiName,
-	options?: QueryHookOptions<any, OperationVariables> | undefined,
+	query: QueryType<TData, TVariables>,
+	api: APIType,
+	options?: OptionsType,
 ): QueryResult<TData, TVariables> => {
 	const mergedOptions = { context: { apiName: api }, ...options };
 	// @ts-expect-error apollo NoInfer type isn't playing nice with the 'mergedOptions'
@@ -37,15 +42,40 @@ const useApolloQuery = <TData, TVariables>(
 };
 
 export const useGatewayQuery = <TData, TVariables>(
-	query: DocumentNode | TypedDocumentNode<TData, TVariables>,
-	options?: QueryHookOptions<any, OperationVariables> | undefined,
+	query: QueryType<TData, TVariables>,
+	options?: OptionsType,
 ) => {
 	return useApolloQuery(query, apiName.gateway, options);
 };
 
 export const useClinicalQuery = <TData, TVariables>(
-	query: DocumentNode | TypedDocumentNode<TData, TVariables>,
-	options?: QueryHookOptions<any, OperationVariables> | undefined,
+	query: QueryType<TData, TVariables>,
+	options?: OptionsType,
 ) => {
 	return useApolloQuery(query, apiName.clinical, options);
+};
+
+// Mutation
+const useApolloMutation = <TData, TVariables>(
+	mutation: QueryType<TData, TVariables>,
+	api: APIType,
+	options?: OptionsType,
+) => {
+	const mergedOptions = { context: { apiName: api }, ...options };
+	// @ts-expect-error apollo NoInfer type isn't playing nice with the 'mergedOptions'
+	return useMutation(mutation, mergedOptions);
+};
+
+export const useGatewayMutation = <TData, TVariables>(
+	mutation: QueryType<TData, TVariables>,
+	options?: OptionsType,
+) => {
+	return useApolloMutation(mutation, apiName.gateway, options);
+};
+
+export const useClinicalMutation = <TData, TVariables>(
+	mutation: QueryType<TData, TVariables>,
+	options?: OptionsType,
+) => {
+	return useApolloMutation(mutation, apiName.clinical, options);
 };

--- a/src/app/hooks/useApolloQuery.tsx
+++ b/src/app/hooks/useApolloQuery.tsx
@@ -30,6 +30,7 @@ import {
 type APIType = keyof typeof apiName;
 type QueryType<TData, TVariables> = DocumentNode | TypedDocumentNode<TData, TVariables>;
 type OptionsType = QueryHookOptions<any, OperationVariables> | undefined;
+type MutationOptions = OptionsType & { refetchQueries?: any };
 
 const useApolloQuery = <TData, TVariables>(
 	query: QueryType<TData, TVariables>,
@@ -59,7 +60,7 @@ export const useClinicalQuery = <TData, TVariables>(
 const useApolloMutation = <TData, TVariables>(
 	mutation: QueryType<TData, TVariables>,
 	api: APIType,
-	options?: OptionsType,
+	options?: MutationOptions,
 ) => {
 	const mergedOptions = { context: { apiName: api }, ...options };
 	// @ts-expect-error apollo NoInfer type isn't playing nice with the 'mergedOptions'
@@ -68,14 +69,14 @@ const useApolloMutation = <TData, TVariables>(
 
 export const useGatewayMutation = <TData, TVariables>(
 	mutation: QueryType<TData, TVariables>,
-	options?: OptionsType,
+	options?: MutationOptions,
 ) => {
 	return useApolloMutation(mutation, apiName.gateway, options);
 };
 
 export const useClinicalMutation = <TData, TVariables>(
 	mutation: QueryType<TData, TVariables>,
-	options?: OptionsType,
+	options?: MutationOptions,
 ) => {
 	return useApolloMutation(mutation, apiName.clinical, options);
 };


### PR DESCRIPTION
- use gql route splitting so mutations hit the correct endpoints