### PR TITLE
Sync http gql

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,12 @@ In an attempt to try and keep things clean and bug free, Emotion functions are u
 @emotion/react is only installed as a dependency in this project for types.
 
 react + react dom + emotion all versions needs to be in sync with @icgc-argo/uikit
+
+## API Requests
+We use both regular style HTTP endpoints and GQL endpoints.
+We use Apollo GQL store on the frontend for most state.
+
+Any queries that are NOT GQL and do not have persisted state on the server will need to manually update the Apollo store.
+https://www.apollographql.com/docs/react/data/mutations/
+
+If there is persisted state on the server, it's possible to use the Apollo `refetch` function to have the Apollo store sync.

--- a/src/app/(post-login)/submission/program/[shortName]/sample-registration/components/Instructions.tsx
+++ b/src/app/(post-login)/submission/program/[shortName]/sample-registration/components/Instructions.tsx
@@ -55,7 +55,7 @@ const Instructions = ({
 	flags,
 }: {
 	dictionaryVersion: string;
-	handleUpload: (f: File) => void;
+	handleUpload: (f: FileList) => void;
 	isUploading: boolean;
 	handleRegister: () => void;
 	flags: { uploadEnabled: boolean; registrationEnabled: boolean };
@@ -113,7 +113,7 @@ const Instructions = ({
 							size={BUTTON_SIZES.SM}
 							isLoading={isUploading}
 							onFilesSelect={async (files) => {
-								if (files[0]) await handleUpload(files[0]);
+								if (files[0]) await handleUpload(files);
 							}}
 							disabled={!flags.uploadEnabled}
 						>

--- a/src/app/(post-login)/submission/program/[shortName]/sample-registration/page.tsx
+++ b/src/app/(post-login)/submission/program/[shortName]/sample-registration/page.tsx
@@ -115,7 +115,7 @@ const Register = ({ shortName }: { shortName: string }) => {
 		},
 	);
 
-	const handleUpload = (file: File) => {
+	const handleUpload = (file: FileList) => {
 		const fileFormData = createFileFormData(file, 'registrationFile');
 		return uploadFile.mutate(fileFormData);
 	};

--- a/src/global/utils/form.ts
+++ b/src/global/utils/form.ts
@@ -20,7 +20,7 @@
 export const createFileFormData = (upload: FileList, uploadName) => {
 	const formData = new FormData();
 
-	[...upload].forEach((file) => {
+	[...upload].forEach((file, i) => {
 		formData.append(uploadName || `file_${i}`, file);
 	});
 


### PR DESCRIPTION
### Sample reg page
- error states are not persisted server side, success states are
- we use a mixture of regular HTTP calls and GQL calls
- on success we can simply refetch and sync with successful state on server
- on error we need to manually update our local apollo cache (state) 
  - cache needs to take same shape as GQL types, server is no longer providing same shape in HTTP calls
  
  
- Functions added for this use case - I think there's more cases where this is happening - keeping this PR small and easy to review


- There is still an issue with error state when navigating back to the sample reg page but this is because of Auth state ( I think ) causing app level re-renders. This PR fixed page level state issues.