### PR TITLE
Routing state fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "npm run clean && next dev",
     "build": "npm run clean && NEXT_IS_BUILDING=true next build",
+    "serve": "npm run clean && next build && next start",
     "start": "next start",
     "lint": "next lint",
     "prepare": "husky install",

--- a/src/components/ProgramMenu.tsx
+++ b/src/components/ProgramMenu.tsx
@@ -181,7 +181,7 @@ const renderDataSubmissionLinks = (
 	programStatusData?: ReturnType<typeof parseProgramStatusGQLResp>,
 ) => (
 	<>
-		<Link href={registrationPath}>
+		<Link href={registrationPath} legacyBehavior>
 			<MenuItem
 				level={3}
 				content={
@@ -195,7 +195,7 @@ const renderDataSubmissionLinks = (
 		</Link>
 
 		{/** Submit clinical data */}
-		<Link href={submissionPath}>
+		<Link href={submissionPath} legacyBehavior>
 			<MenuItem
 				level={3}
 				content={
@@ -275,11 +275,13 @@ const MenuContent = ({ programName }: { programName: string }) => {
 	) : programStatusData?.clinicalRegistrationInProgress ? (
 		<Icon name="ellipses" fill="warning" width="15px" />
 	) : null;
+	const route = getProgramPath(PROGRAM_DASHBOARD_PATH, programName);
 
 	return (
 		<>
 			{/** Dashboard */}
-			<Link href={getProgramPath(PROGRAM_DASHBOARD_PATH, programName)}>
+
+			<Link href={route} legacyBehavior>
 				<MenuItem level={3} content="Dashboard" selected={pathnameLastSegment === 'dashboard'} />
 			</Link>
 
@@ -296,7 +298,7 @@ const MenuContent = ({ programName }: { programName: string }) => {
 
 			{/** Submitted Data */}
 			{userCanViewData && (
-				<Link href={getProgramPath(PROGRAM_CLINICAL_DATA_PATH, programName)}>
+				<Link href={getProgramPath(PROGRAM_CLINICAL_DATA_PATH, programName)} legacyBehavior>
 					<MenuItem
 						level={3}
 						content={

--- a/src/views/submission/clinical-data/ClinicalEntityDataTable/components.tsx
+++ b/src/views/submission/clinical-data/ClinicalEntityDataTable/components.tsx
@@ -61,7 +61,10 @@ export const Subtitle = ({ program = '' }) => {
 			</Link>{' '}
 			of the data dictionary was released and has made some donors invalid. Please download the
 			error report to view the affected donors, then submit a corrected TSV file in the{' '}
-			<Link href={PROGRAM_CLINICAL_SUBMISSION_PATH.replace(PROGRAM_SHORT_NAME_PATH, program)}>
+			<Link
+				href={PROGRAM_CLINICAL_SUBMISSION_PATH.replace(PROGRAM_SHORT_NAME_PATH, program)}
+				legacyBehavior
+			>
 				Submit Clinical Data{' '}
 			</Link>
 			workspace.


### PR DESCRIPTION
- use legacy behaviour for Link client side routing so it accept child props in the same way we've used on platform-ui